### PR TITLE
Install docker-engine instead of docker package

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -60,7 +60,7 @@
 - name: Install packages
   yum: name={{ item }} state=present
   with_items:
-  - docker
+  - docker-engine
   - kubeadm
 
 - name: Enable and start docker


### PR DESCRIPTION
docker-engine is provided by yum.dockerproject.org, docker is provided by extras repo and much older (1.13) at the time of writing.